### PR TITLE
regex test against the entire filepath

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ fss.errorHandler = function(err) {
     } else {
       throw err;
     }
-  }  
+  }
 };
 
 
@@ -45,20 +45,20 @@ var error = {
 
 var is = (function() {
   function existed(name) {
-    return fs.existsSync(name) 
-  } 
+    return fs.existsSync(name)
+  }
   function fsType(type) {
     return function(name) {
       try {
-        return fs.lstatSync(name)['is' + type]() 
+        return fs.lstatSync(name)['is' + type]()
       } catch(e) {
         fss.errorHandler(e);
       }
     }
-  } 
+  }
   function objType(type) {
     return function(input) {
-      return ({}).toString.call(input) === '[object ' + type +  ']'; 
+      return ({}).toString.call(input) === '[object ' + type +  ']';
     }
   }
   return {
@@ -71,7 +71,7 @@ var is = (function() {
     regexp:       objType('RegExp'),
     func:         objType('Function')
   };
-}()); 
+}());
 
 
 /**
@@ -117,23 +117,23 @@ fss.readlinkSync = function(name, depth) {
   } else {
     return isSymbolicLink ? '' : path.resolve(name);
   }
-}  
+}
 
 
 /**
- * Check pattern with path's basename 
+ * Check pattern against the path
  */
 var compare = function(pat, name) {
   var str = path.basename(name);
   return (
-       is.regexp(pat)   && pat.test(str) 
+       is.regexp(pat) && pat.test(name)
     || is.string(pat) && pat === str
-  ); 
+  );
 };
 
 
 /**
- * Traverse a directory recursively and asynchronously. 
+ * Traverse a directory recursively and asynchronously.
  *
  * @param {String} root
  * @param {String} type
@@ -154,12 +154,12 @@ var traverseAsync = function(root, type, action, callback, c) {
         chain.add(function() {
           var handleFile = function() {
             if (type == 'file') action(dir);
-            chain.next(); 
+            chain.next();
           }
           var handleDir = function(skip) {
             if (type == 'dir') action(dir);
             if (skip) chain.next();
-            else traverseAsync(dir, type, action, callback, chain);  
+            else traverseAsync(dir, type, action, callback, chain);
           }
           var isSymbolicLink = is.symbolicLink(dir);
           if (is.directory(dir)) {
@@ -174,7 +174,7 @@ var traverseAsync = function(root, type, action, callback, c) {
             });
           } else {
             handleFile();
-          } 
+          }
         })
       });
       chain.traverse(function() {
@@ -184,7 +184,7 @@ var traverseAsync = function(root, type, action, callback, c) {
   }
 }
 
- 
+
 /**
  * Traverse a directory recursively.
  *
@@ -193,7 +193,7 @@ var traverseAsync = function(root, type, action, callback, c) {
  * @param {Function} action
  * @return {Array} the result
  * @api private
- */  
+ */
 var traverseSync = function(root, type, action) {
   if (!is.existed(root)) throw error.notExist(root);
   if (is.directory(root)) {
@@ -202,7 +202,7 @@ var traverseSync = function(root, type, action) {
       var handleDir = function(skip) {
         if (type == 'dir') action(dir);
         if (skip) return;
-        traverseSync(dir, type, action); 
+        traverseSync(dir, type, action);
       }
       var handleFile = function() {
         if (type == 'file') action(dir);
@@ -217,33 +217,33 @@ var traverseSync = function(root, type, action) {
         }
       } else {
         handleFile();
-      } 
+      }
     });
   }
 };
 
 
 ['file', 'dir'].forEach(function(type) {
-  
+
   /**
-   * `find.file` and `find.dir` 
-   * 
-   * Find files or sub-directories in a given directory and 
-   * passes the result in an array as a whole. This follows 
-   * the default callback style of nodejs, think about `fs.readdir`, 
+   * `find.file` and `find.dir`
    *
-   * @param {RegExp|String} pat 
+   * Find files or sub-directories in a given directory and
+   * passes the result in an array as a whole. This follows
+   * the default callback style of nodejs, think about `fs.readdir`,
+   *
+   * @param {RegExp|String} pat
    * @param {String} root
    * @param {Function} fn
    * @api public
-   */ 
+   */
   find[type] = function(pat, root, fn) {
     var buffer = [];
     if (arguments.length == 2) {
       fn = root;
       root = pat;
       pat = '';
-    } 
+    }
     process.nextTick(function() {
       traverseAsync(
         root
@@ -263,33 +263,33 @@ var traverseSync = function(root, type, action) {
     return {
       error: function(handler) {
         if (is.func(handler)) {
-          find.__errorHandler = handler;  
-        } 
+          find.__errorHandler = handler;
+        }
       }
     }
   }
 
   /**
    * `find.eachfile` and `find.eachdir`
-   * 
-   * Find files or sub-directories in a given directory and 
-   * apply with a given action to each result immediately 
+   *
+   * Find files or sub-directories in a given directory and
+   * apply with a given action to each result immediately
    * rather than pass them back as an array.
    *
-   * @param {RegExp|String} pat 
+   * @param {RegExp|String} pat
    * @param {String} root
    * @param {Function} action
    * @return {Object} for chain methods
    * @api public
-   *  
-   */ 
+   *
+   */
   find['each' + type] = function(pat, root, action) {
     var callback = function() {}
     if (arguments.length == 2) {
       action = root;
       root = pat;
       pat = '';
-    } 
+    }
     process.nextTick(function() {
       traverseAsync(
           root
@@ -309,10 +309,10 @@ var traverseSync = function(root, type, action) {
           callback = fn;
         }
         return this;
-      }, 
+      },
       error: function(handler) {
         if (is.func(handler)) {
-          find.__errorHandler = handler;    
+          find.__errorHandler = handler;
         }
         return this;
       }
@@ -320,17 +320,17 @@ var traverseSync = function(root, type, action) {
   }
 
   /**
-   * `find.fileSync` and `find.dirSync` 
+   * `find.fileSync` and `find.dirSync`
    *
-   * Find files or sub-directories in a given directory synchronously 
-   * and returns the result as an array. This follows the default 'Sync' 
-   * methods of nodejs, think about `fs.readdirSync`, 
+   * Find files or sub-directories in a given directory synchronously
+   * and returns the result as an array. This follows the default 'Sync'
+   * methods of nodejs, think about `fs.readdirSync`,
    *
-   * @param {RegExp|String} pat 
+   * @param {RegExp|String} pat
    * @param {String} root
    * @return {Array} the result
    * @api public
-   */ 
+   */
   find[type + 'Sync'] = function(pat, root) {
     var buffer = [];
     if (arguments.length == 1) {
@@ -338,12 +338,12 @@ var traverseSync = function(root, type, action) {
       pat = '';
     }
     traverseSync(root, type, function(n) {
-      buffer.push(n);  
+      buffer.push(n);
     });
     return pat && buffer.filter(function(n) {
       return compare(pat, n);
     }) || buffer;
-  } 
+  }
 
-}); 
+});
 

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ function createBy(type) {
     for (var i = 0; i < num; ++i) {
       targets.push(tmp[type + 'Sync'](opts).name);
     }
-    return targets; 
+    return targets;
   }
 }
 
@@ -51,7 +51,7 @@ describe('API test', function() {
       assertEqual(expect, found);
       done();
     });
-  });   
+  });
 
   it('`find.file()` should find recursively', function(done) {
     var expect = createFilesUnder(testdir, 3);
@@ -62,7 +62,7 @@ describe('API test', function() {
       assertEqual(expect, found);
       done();
     });
-  });   
+  });
 
   it('`find.dir()` should find all dirs just like find.file()', function(done) {
     var expect = createNestedDirs(testdir);
@@ -70,7 +70,7 @@ describe('API test', function() {
       assertEqual(expect, found);
       done();
     });
-  });     
+  });
 
   it('`find.eachfile()` should find all files and process one by one', function(done) {
     var expect = createFilesUnder(testdir, 3);
@@ -82,7 +82,7 @@ describe('API test', function() {
       assert(count == expect.length);
       done();
     });
-  });     
+  });
 
   it('`find.eachdir()` should find all dirs just like find.eachfile()', function(done) {
     var expect = createNestedDirs(testdir);
@@ -92,23 +92,21 @@ describe('API test', function() {
       count++;
     }).end(function() {
       assert(count == expect.length);
-      done();   
+      done();
     });
-  });     
+  });
 
-  it('`find.fileSync()` should find all files synchronously', function(done) {
+  it('`find.fileSync()` should find all files synchronously', function() {
     var expect = createFilesUnder(testdir, 3);
     var found = find.fileSync(testdir);
     assertEqual(expect, found);
-    done();
   });
 
-  it('`find.dirSync()` should find all dirs synchronously', function(done) {
+  it('`find.dirSync()` should find all dirs synchronously', function() {
     var expect = createNestedDirs(testdir, 3);
     var found = find.dirSync(testdir);
     assertEqual(expect, found);
-    done();
-  }); 
+  });
 
   it('`find.*` should find by name', function(done) {
     var expect = createFilesUnder(testdir, 3);
@@ -117,9 +115,9 @@ describe('API test', function() {
       assert.equal(first, found[0]);
       done();
     });
-  });    
+  });
 
-  it('`find.*` should find by regular expression', function(done) {
+  it('`find.*` should find by regular expression', function() {
     var html = createFilesUnder(testdir, 1, '.html');
     var js = createFilesUnder(testdir, 2, '.js');
 
@@ -128,8 +126,15 @@ describe('API test', function() {
 
     jsAll = find.fileSync(/\.js$/, testdir);
     assertEqual(js, jsAll);
-    done();
-  });          
+  });
+
+  it('`find.*` should find by regular expression against the full path', function() {
+    var html = createFilesUnder(testdir, 1, '.html')[0];
+    var extensionless = path.join(path.dirname(html), path.basename(html, '.html'));
+
+    htmlAll = find.fileSync(new RegExp(extensionless), testdir);
+    assert.equal( html, htmlAll.join(''));
+  });
 
   it('`find.*` should follow file symbolic links', function(done) {
     var files = createFilesUnder(testdir, 2);
@@ -145,7 +150,7 @@ describe('API test', function() {
       assertEqual(files, found);
       done();
     });
-  });       
+  });
 
   it('`find.*` should follow direcotry symbolic links', function(done) {
     createFilesUnder(testdir, 2);
@@ -163,8 +168,7 @@ describe('API test', function() {
       assertEqual(dirs, found);
       done();
     });
-    
-  });       
+  });
 
   it('`find.file(Sync)` should ignore circular symbolic links', function(done) {
     var files = createFilesUnder(testdir, 2);
@@ -174,9 +178,9 @@ describe('API test', function() {
     var b = src + '-link-b';
     var c = src + '-link-c';
 
-    fs.symlinkSync(src, a, 'file'); 
-    fs.symlinkSync(a, b, 'file'); 
-    fs.symlinkSync(b, c, 'file'); 
+    fs.symlinkSync(src, a, 'file');
+    fs.symlinkSync(a, b, 'file');
+    fs.symlinkSync(b, c, 'file');
     fs.unlinkSync(src);
     fs.symlinkSync(c, src, 'file');
 
@@ -197,9 +201,9 @@ describe('API test', function() {
     var b = src + '-link-b';
     var c = src + '-link-c';
 
-    fs.symlinkSync(src, a, 'dir'); 
-    fs.symlinkSync(a, b, 'dir'); 
-    fs.symlinkSync(b, c, 'dir'); 
+    fs.symlinkSync(src, a, 'dir');
+    fs.symlinkSync(a, b, 'dir');
+    fs.symlinkSync(b, c, 'dir');
     fs.rmdirSync(src);
     fs.symlinkSync(c, src, 'dir');
 
@@ -210,7 +214,6 @@ describe('API test', function() {
       assertEqual(remaining, found);
       done();
     })
-    
   });
 
   it('should throw exception at root which does not exist', function(done) {
@@ -224,8 +227,8 @@ describe('API test', function() {
       assert(catched);
       done();
     });
-  }); 
-  
+  });
+
   it('`.error()`should catch exceptions', function(done) {
     var catched;
     try {
@@ -242,5 +245,4 @@ describe('API test', function() {
       done();
     });
   });
-
 });


### PR DESCRIPTION
I needed this functionality for the following find regex scenario:

I need the file `/Users/mrjoelkemp/Documents/node-module-lookup-amd/test/example/js/b.js` to match the pattern `/\/Users\/mrjoelkemp\/Documents\/node\-module\-lookup\-amd\/test\/example\/js\/b\./`.

In this example, I don't have a file extension and need to look for a file that closely matches a specific pattern. Searching only for `b\.` would yield a large number of false positives – hence the need for a path match, not a basename match.

The only real changes are here:

* Code change: https://github.com/yuanchuan/find/compare/master...mrjoelkemp:improvements?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR129
* Test: https://github.com/yuanchuan/find/compare/master...mrjoelkemp:improvements?expand=1#diff-c1129c8b045390789fa8ff62f2c6b4a9R131

All of the other changes are due to the elimination of trailing whitespace. 