### PR TITLE
Fix max call stack exceeded error

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,12 +160,12 @@ var traverseAsync = function(root, type, action, callback, c) {
         chain.add(function() {
           var handleFile = function() {
             if (type == 'file') action(dir);
-            chain.next();
+            process.nextTick(function() { chain.next() });
           }
           var handleDir = function(skip) {
             if (type == 'dir') action(dir);
             if (skip) chain.next();
-            else traverseAsync(dir, type, action, callback, chain);
+            else process.nextTick(function() { traverseAsync(dir, type, action, callback, chain)});
           }
           var isSymbolicLink = is.symbolicLink(dir);
           if (is.directory(dir)) {


### PR DESCRIPTION
@yuanchuan ?

If a directory has a lot of files (in my case around 80,000) then I get a max call stack exceeded error.