### PR TITLE
Allow alternative fs to be provided, and fix tests on windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.0",
+    "configurations": [        
+        {
+            "name": "Run mocha",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "stopOnEntry": false,
+            "args": [                
+                "test/test.js",
+                "--no-timeouts"                
+            ],
+            "sourceMaps": true,
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": null,
+            "env": {
+                "NODE_ENV": "testing"
+            }
+        }
+    ]
+}

--- a/index.js
+++ b/index.js
@@ -2,24 +2,6 @@ var fs = require('fs');
 var path = require('path');
 var Chain = require('traverse-chain');
 
-
-/**
- * Outline the APIs.
- */
-var find = module.exports = {
-
-  // file:      function([pat,] root, callback) {}
-  // dir:       function([pat,] root, callback) {}
-
-  // eachfile:  function([pat,] root, action) {}
-  // eachdir:   function([pat,] root, action) {}
-
-  // fileSync:  function([pat,] root) {}
-  // dirSync:   function([pat,] root) {}
-
-};
-
-
 var fss = {};
 
 /**
@@ -27,14 +9,15 @@ var fss = {};
  */
 fss.errorHandler = function(err) {
   if (err) {
-    if (find.__errorHandler) {
-      find.__errorHandler(err);
+    if (module.exports.__errorHandler) {
+      module.exports.__errorHandler(err);
     } else {
       throw err;
     }
   }
 };
 
+fss.fileSystem = fs;
 
 var error = {
   notExist: function(name) {
@@ -42,99 +25,15 @@ var error = {
   }
 };
 
-
-var is = (function() {
-  function existed(name) {
-    return fs.existsSync(name)
-  }
-  function fsType(type) {
-    return function(name) {
-      try {
-        return fs.lstatSync(name)['is' + type]()
-      } catch(e) {
-        fss.errorHandler(e);
-      }
-    }
-  }
-  function objType(type) {
-    return function(input) {
-      return ({}).toString.call(input) === '[object ' + type +  ']';
-    }
-  }
-  return {
-    existed:      existed,
-    file:         fsType('File'),
-    directory:    fsType('Directory'),
-    symbolicLink: fsType('SymbolicLink'),
-
-    string:       objType('String'),
-    regexp:       objType('RegExp'),
-    func:         objType('Function')
-  };
-}());
-
-
-/**
- *  Method injection for handling errors.
- */
-['readdir', 'lstat'].forEach(function(method) {
-  var origin = fs[method];
-  fss[method] = function(path, callback) {
-    return origin.apply(fs, [path, function(err) {
-      fss.errorHandler(err);
-      return callback.apply(null, arguments);
-    }]);
-  }
-});
-
-
-/**
- * Enhancement for fs.readlink && fs.readlinkSync.
- */
-fss.readlink = function(name, fn, depth) {
-  if (depth == undefined) depth = 5;
-  if (!is.existed(name) && (depth < 5)) {
-    return fn(path.resolve(name));
-  }
-  var isSymbolicLink = is.symbolicLink(name);
-  if (!isSymbolicLink) {
-    fn(path.resolve(name));
-  } else if (depth) {
-    fs.realpath(name, function(err, origin) {
-      if (err && /(ENOENT|ELOOP)/.test(err.code)) {
-        fn(name);
-      } else {
-        fss.errorHandler(err);
-        fss.readlink(origin, fn, --depth);
-      }
-    });
-  } else {
-    fn(isSymbolicLink ? '' : path.resolve(name));
+var objType = function(type) {
+  return function(input) {
+    return ({}).toString.call(input) === '[object ' + type +  ']';
   }
 }
 
-fss.readlinkSync = function(name, depth) {
-  if (depth == undefined) depth = 5;
-  if (!is.existed(name) && depth < 5) {
-    return path.resolve(name);
-  }
-  var isSymbolicLink = is.symbolicLink(name);
-  if (!isSymbolicLink) {
-    return path.resolve(name);
-  } else if (depth) {
-    var origin;
-    try {
-      origin = fs.realpathSync(name);
-    } catch (err) {
-      if (/(ENOENT|ELOOP)/.test(err.code)) return name;
-      else fss.errorHandler(err);
-    }
-    return fss.readlinkSync(origin, --depth);
-  } else {
-    return isSymbolicLink ? '' : path.resolve(name);
-  }
-}
-
+var isString = objType('String');
+var isRegexp = objType('RegExp');
+var isFunc = objType('Function');
 
 /**
  * Check pattern against the path
@@ -142,169 +41,278 @@ fss.readlinkSync = function(name, depth) {
 var compare = function(pat, name) {
   var str = path.basename(name);
   return (
-       is.regexp(pat) && pat.test(name)
-    || is.string(pat) && pat === str
+    isRegexp(pat) && pat.test(name)
+    || isString(pat) && pat === str
   );
 };
 
+var createInstance = function(fileSystem, errHandler) {
 
-/**
- * Traverse a directory recursively and asynchronously.
- *
- * @param {String} root
- * @param {String} type
- * @param {Function} action
- * @param {Function} callback
- * @param {Chain} c
- * @api private
- */
-var traverseAsync = function(root, type, action, callback, c) {
-  if (!is.existed(root)) {
-    fss.errorHandler(error.notExist(root))
+  var internalApi = {}; 
+  internalApi.fileSystem = fileSystem || fss.fileSystem;
+  internalApi.errHandler = errHandler || fss.errorHandler;
+
+  function existed(name) {
+    return internalApi.fileSystem.existsSync(name)
   }
-
-  var originRoot = root;
-  if (is.symbolicLink(root)) {
-    root = fss.readlinkSync(root);
-  }
-
-  if (is.directory(root)) {
-    fss.readdir(root, function(err, all) {
-      var chain = Chain();
-      all && all.forEach(function(dir) {
-        dir = path.join(originRoot, dir);
-        chain.add(function() {
-          var handleFile = function() {
-            if (type == 'file') action(dir);
-            process.nextTick(function() { chain.next() });
-          }
-          var handleDir = function(skip) {
-            if (type == 'dir') action(dir);
-            if (skip) chain.next();
-            else process.nextTick(function() { traverseAsync(dir, type, action, callback, chain)});
-          }
-          var isSymbolicLink = is.symbolicLink(dir);
-          if (is.directory(dir)) {
-            handleDir();
-          } else if (isSymbolicLink) {
-            fss.readlink(dir, function(origin) {
-              if (origin) {
-                if (is.existed(origin) && is.directory(origin)) {
-                  handleDir(isSymbolicLink)
-                } else {
-                  handleFile()
-                }
-              } else {
-                chain.next();
-              }
-            });
-          } else {
-            handleFile();
-          }
-        })
-      });
-      chain.traverse(function() {
-        c ? c.next() : callback();
-      });
-    });
-  }
-}
-
-
-/**
- * Traverse a directory recursively.
- *
- * @param {String} root
- * @param {String} type
- * @param {Function} action
- * @return {Array} the result
- * @api private
- */
-var traverseSync = function(root, type, action) {
-  if (!is.existed(root)) throw error.notExist(root);
-  var originRoot = root;
-  if (is.symbolicLink(root)) {
-    root = fss.readlinkSync(root);
-  }
-  if (is.directory(root)) {
-    fs.readdirSync(root).forEach(function(dir) {
-      dir = path.join(originRoot, dir);
-      var handleDir = function(skip) {
-        if (type == 'dir') action(dir);
-        if (skip) return;
-        traverseSync(dir, type, action);
+  function fsType(type) {
+    return function(name) {
+      try {
+        return internalApi.fileSystem.lstatSync(name)['is' + type]()
+      } catch(e) {
+        internalApi.errHandler(e);
       }
-      var handleFile = function() {
-        if (type == 'file') action(dir);
-      }
-      var isSymbolicLink = is.symbolicLink(dir);
-      if (is.directory(dir)) {
-        handleDir();
-      } else if (isSymbolicLink) {
-        var origin = fss.readlinkSync(dir);
-        if (origin) {
-          if (is.existed(origin) && is.directory(origin)) {
-            handleDir(isSymbolicLink);
-          } else {
-            handleFile();
-          }
-        }
-      } else {
-        handleFile();
-      }
-    });
-  }
-};
+    }
+  }  
 
+  ['readdir', 'lstat'].forEach(function(method) {
+    var origin = internalApi.fileSystem[method];
+    internalApi[method] = function(path, callback) {
+      return origin.apply(internalApi.fileSystem, [path, function(err) {
+        internalApi.errHandler(err);
+        return callback.apply(null, arguments);
+      }]);
+    }
+  });
 
-['file', 'dir'].forEach(function(type) {
+  var publicApi = {
+    existed:      existed,
+    file:         fsType('File'),
+    directory:    fsType('Directory'),
+    symbolicLink: fsType('SymbolicLink')         
+  };
 
   /**
-   * `find.file` and `find.dir`
+  * Enhancement for fs.readlink && fs.readlinkSync.
+  */
+ internalApi.readlink = function(name, fn, depth) {
+    if (depth == undefined) depth = 5;
+    if (!publicApi.existed(name) && (depth < 5)) {
+      return fn(path.resolve(name));
+    }
+    var isSymbolicLink = publicApi.symbolicLink(name);
+    if (!isSymbolicLink) {
+      fn(path.resolve(name));
+    } else if (depth) {
+      internalApi.fileSystem.realpath(name, function(err, origin) {
+        if (err && /(ENOENT|ELOOP)/.test(err.code)) {
+          fn(name);
+        } else {
+          internalApi.errHandler(err);
+          internalApi.readlink(origin, fn, --depth);
+        }
+      });
+    } else {
+      fn(isSymbolicLink ? '' : path.resolve(name));
+    }
+  }  
+
+  internalApi.readlinkSync = function(name, depth) {
+    if (depth == undefined) depth = 5;
+    if (!publicApi.existed(name) && depth < 5) {
+      return path.resolve(name);
+    }
+    var isSymbolicLink = publicApi.symbolicLink(name);
+    if (!isSymbolicLink) {
+      return path.resolve(name);
+    } else if (depth) {
+      var origin;
+      try {
+        origin = internalApi.fileSystem.realpathSync(name);
+      } catch (err) {
+        if (/(ENOENT|ELOOP)/.test(err.code)) return name;
+        else internalApi.errHandler(err);
+      }
+      return internalApi.readlinkSync(origin, --depth);
+    } else {
+      return isSymbolicLink ? '' : path.resolve(name);
+    }
+  }
+
+    /**
+   * Traverse a directory recursively.
    *
-   * Find files or sub-directories in a given directory and
-   * passes the result in an array as a whole. This follows
-   * the default callback style of nodejs, think about `fs.readdir`,
+   * @param {String} root
+   * @param {String} type
+   * @param {Function} action
+   * @return {Array} the result
+   * @api private
+   */
+  internalApi.traverseSync = function(root, type, action) {
+    if (!publicApi.existed(root)) throw error.notExist(root);
+    var originRoot = root;
+    if (publicApi.symbolicLink(root)) {
+      root = internalApi.readlinkSync(root);
+    }
+    if (publicApi.directory(root)) {
+      internalApi.fileSystem.readdirSync(root).forEach(function(dir) {
+        dir = path.join(originRoot, dir);
+        var handleDir = function(skip) {
+          if (type == 'dir') action(dir);
+          if (skip) return;
+          internalApi.traverseSync(dir, type, action);
+        }
+        var handleFile = function() {
+          if (type == 'file') action(dir);
+        }
+        var isSymbolicLink = publicApi.symbolicLink(dir);
+        if (publicApi.directory(dir)) {
+          handleDir();
+        } else if (isSymbolicLink) {
+          var origin = internalApi.readlinkSync(dir);
+          if (origin) {
+            if (publicApi.existed(origin) && publicApi.directory(origin)) {
+              handleDir(isSymbolicLink);
+            } else {
+              handleFile();
+            }
+          }
+        } else {
+          handleFile();
+        }
+      });
+    }
+  }
+
+    /**
+   * Traverse a directory recursively and asynchronously.
+   *
+   * @param {String} root
+   * @param {String} type
+   * @param {Function} action
+   * @param {Function} callback
+   * @param {Chain} c
+   * @param {Object}
+   * @api private
+   */
+  internalApi.traverseAsync = function(root, type, action, callback, c) {
+    if (!publicApi.existed(root)) {
+      internalApi.errHandler(error.notExist(root))
+    }
+
+    var originRoot = root;
+    if (publicApi.symbolicLink(root)) {
+      root = internalApi.readlinkSync(root);
+    }
+
+    if (publicApi.directory(root)) {
+      internalApi.readdir(root, function(err, all) {
+        var chain = Chain();
+        all && all.forEach(function(dir) {
+          dir = path.join(originRoot, dir);
+          chain.add(function() {
+            var handleFile = function() {
+              if (type == 'file') action(dir);
+              process.nextTick(function() { chain.next() });
+            }
+            var handleDir = function(skip) {
+              if (type == 'dir') action(dir);
+              if (skip) chain.next();
+              else process.nextTick(function() { internalApi.traverseAsync(dir, type, action, callback, chain)});
+            }
+            var isSymbolicLink = publicApi.symbolicLink(dir);
+            if (publicApi.directory(dir)) {
+              handleDir();
+            } else if (isSymbolicLink) {
+              internalApi.readlink(dir, function(origin) {
+                if (origin) {
+                  if (publicApi.existed(origin) && publicApi.directory(origin)) {
+                    handleDir(isSymbolicLink)
+                  } else {
+                    handleFile()
+                  }
+                } else {
+                  chain.next();
+                }
+              });
+            } else {
+              handleFile();
+            }
+          })
+        });
+        chain.traverse(function() {
+          c ? c.next() : callback();
+        });
+      });
+    }
+  };
+
+
+  ['file', 'dir'].forEach(function(type) {
+
+    /**
+     * `find.file` and `find.dir`
+     *
+     * Find files or sub-directories in a given directory and
+     * passes the result in an array as a whole. This follows
+     * the default callback style of nodejs, think about `fs.readdir`,
+     *
+     * @param {RegExp|String} pat
+     * @param {String} root
+     * @param {Function} fn
+     * @api public
+     */
+    publicApi[type] = function(pat, root, fn) {
+      var buffer = [];
+      if (arguments.length == 2) {
+        fn = root;
+        root = pat;
+        pat = '';
+      }
+      process.nextTick(function() {
+        internalApi.traverseAsync(
+          root
+        , type
+        , function(n) { buffer.push(n);}
+        , function() {
+            if (isFunc(fn) && pat) {
+              fn(buffer.filter(function(n) {
+                return compare(pat, n);
+              }));
+            } else {
+              fn(buffer);
+            }
+          }
+        );
+      });
+      return {
+        error: function(handler) {
+          if (isFunc(handler)) {
+            module.exports.__errorHandler = handler;
+          }
+        }
+      }
+    }
+
+  /**
+   * `fileSync` and `dirSync`
+   *
+   * Find files or sub-directories in a given directory synchronously
+   * and returns the result as an array. This follows the default 'Sync'
+   * methods of nodejs, think about `fs.readdirSync`,
    *
    * @param {RegExp|String} pat
-   * @param {String} root
-   * @param {Function} fn
+   * @param {String} root   
+   * @return {Array} the result
    * @api public
    */
-  find[type] = function(pat, root, fn) {
+  publicApi[type + 'Sync'] = function(pat, root) {
     var buffer = [];
-    if (arguments.length == 2) {
-      fn = root;
+    if (arguments.length == 1) {
       root = pat;
       pat = '';
     }
-    process.nextTick(function() {
-      traverseAsync(
-        root
-      , type
-      , function(n) { buffer.push(n);}
-      , function() {
-          if (is.func(fn) && pat) {
-            fn(buffer.filter(function(n) {
-              return compare(pat, n);
-            }));
-          } else {
-            fn(buffer);
-          }
-        }
-      );
+    internalApi.traverseSync(root, type, function(n) {
+      buffer.push(n);
     });
-    return {
-      error: function(handler) {
-        if (is.func(handler)) {
-          find.__errorHandler = handler;
-        }
-      }
-    }
+    return pat && buffer.filter(function(n) {
+      return compare(pat, n);
+    }) || buffer;
   }
 
+    
   /**
-   * `find.eachfile` and `find.eachdir`
+   * `eachfile` and `eachdir`
    *
    * Find files or sub-directories in a given directory and
    * apply with a given action to each result immediately
@@ -317,7 +325,7 @@ var traverseSync = function(root, type, action) {
    * @api public
    *
    */
-  find['each' + type] = function(pat, root, action) {
+  publicApi['each' + type] = function(pat, root, action) {
     var callback = function() {}
     if (arguments.length == 2) {
       action = root;
@@ -325,11 +333,11 @@ var traverseSync = function(root, type, action) {
       pat = '';
     }
     process.nextTick(function() {
-      traverseAsync(
+      internalApi.traverseAsync(
           root
         , type
         , function(n) {
-            if (!is.func(action)) return;
+            if (!isFunc(action)) return;
             if (!pat || compare(pat, n)) {
               action(n);
             }
@@ -339,45 +347,41 @@ var traverseSync = function(root, type, action) {
     });
     return {
       end: function(fn) {
-        if (is.func(fn)) {
+        if (isFunc(fn)) {
           callback = fn;
         }
         return this;
       },
       error: function(handler) {
-        if (is.func(handler)) {
-          find.__errorHandler = handler;
+        if (isFunc(handler)) {
+          module.exports.__errorHandler = handler;
         }
         return this;
       }
     };
   }
+});  
 
-  /**
-   * `find.fileSync` and `find.dirSync`
-   *
-   * Find files or sub-directories in a given directory synchronously
-   * and returns the result as an array. This follows the default 'Sync'
-   * methods of nodejs, think about `fs.readdirSync`,
-   *
-   * @param {RegExp|String} pat
-   * @param {String} root
-   * @return {Array} the result
-   * @api public
-   */
-  find[type + 'Sync'] = function(pat, root) {
-    var buffer = [];
-    if (arguments.length == 1) {
-      root = pat;
-      pat = '';
-    }
-    traverseSync(root, type, function(n) {
-      buffer.push(n);
-    });
-    return pat && buffer.filter(function(n) {
-      return compare(pat, n);
-    }) || buffer;
-  }
+  return publicApi;
+};
 
-});
 
+var defaultInstance = createInstance();
+defaultInstance.in = createInstance;
+
+/**
+ * Outline the APIs.
+ */
+ module.exports = defaultInstance;
+
+// module exports set to object that looks like:
+//{
+   // file:      function([pat,] root, callback) {}
+   // dir:       function([pat,] root, callback) {}
+   // eachfile:  function([pat,] root, action) {}
+   // eachdir:   function([pat,] root, action) {}
+   // fileSync:  function([pat,] root) {}
+   // dirSync:   function([pat,] root) {}
+   // in:        function([fs, errHandler]) {}
+//};
+// in is a factory method that creates a new instance of find api, pointing at a specified fs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -71,12 +71,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -103,8 +103,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -119,7 +119,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -167,7 +167,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "os-tmpdir": {
@@ -188,7 +188,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "tmp": {
@@ -197,7 +197,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "traverse-chain": {

--- a/test/test.js
+++ b/test/test.js
@@ -11,12 +11,17 @@ function createBy(type) {
     var targets = [];
     num = num || 1;
     if (Array.isArray(dir)) dir = dir[0];
-    var opts = { template: dir + '/tmp-XXXXXX' + (ext || '') };
+    var nromalised = path.normalize(dir + '/tmp-XXXXXX' + (ext || ''));
+    var opts = { template: nromalised };
     for (var i = 0; i < num; ++i) {
       targets.push(tmp[type + 'Sync'](opts).name);
     }
     return targets;
   }
+}
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
 var createFilesUnder = createBy('file');
@@ -40,7 +45,7 @@ describe('API test', function() {
   beforeEach(function(done) {
     tmp.dir({unsafeCleanup: true}, function(err, dir) {
       if (err) return done(err);
-      testdir = dir;
+      testdir = dir;      
       done();
     });
   });
@@ -130,9 +135,10 @@ describe('API test', function() {
 
   it('`find.*` should find by regular expression against the full path', function() {
     var html = createFilesUnder(testdir, 1, '.html')[0];
-    var extensionless = path.join(path.dirname(html), path.basename(html, '.html'));
+    var extensionless = escapeRegExp(path.join(path.dirname(html), path.basename(html, '.html')));    
+    var regex = new RegExp('^' + extensionless)
 
-    htmlAll = find.fileSync(new RegExp(extensionless), testdir);
+    htmlAll = find.fileSync(regex, testdir);
     assert.equal( html, htmlAll.join(''));
   });
 


### PR DESCRIPTION
So the idea is to allow this library to work with alternative `fs` implementations.

1. So as not to introduce any breaking changes, still export the same interface as before, but with an additional factory method, which is used to create new instances of `find` that wrap a given `fs` and `errorHandler`.
2. The `find` that is exported, is now created using the above factory method, wrapping the default `fs` and errorHandler (as before).


This means people can continue using `find` as before.

However if you would like to use it with an alternative `fs` like `memfs` or `unionfs` you can do so, by doing this:

```
var myFs = getSomeFs();
find.in(myFs).findSync("*.txt");
```

This resolves #18 

In addition to that I also fixed up the tests that were not working on windows due to path handling differences. 
So this also resolves #19 and #20 

There is one test failing on windows still to do with symbolic link handling, but I'll open a seperate issue for that as I believe it's nothing I have changed.


